### PR TITLE
Data fetching optimizations

### DIFF
--- a/prisma/schema_enzymes.prisma
+++ b/prisma/schema_enzymes.prisma
@@ -6,7 +6,7 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/enzymes"
+  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/enzymes?connection_limit=5"
 }
 
 model GeneralInfo {

--- a/prisma/schema_proteins.prisma
+++ b/prisma/schema_proteins.prisma
@@ -6,7 +6,7 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/BglB"
+  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/BglB?connection_limit=5"
 }
 
 model CharacterizationData {

--- a/prisma/schema_publications.prisma
+++ b/prisma/schema_publications.prisma
@@ -6,7 +6,7 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/publications"
+  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/publications?connection_limit=5"
 }
 
 model Papers {

--- a/prisma/schema_users.prisma
+++ b/prisma/schema_users.prisma
@@ -6,7 +6,7 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/users"
+  url      = "mysql://admin:hellothere@d2ddb.ckxjdd4ew6cp.us-east-2.rds.amazonaws.com:3306/users?connection_limit=5"
 }
 
 model Institutions {

--- a/prismaEnzymesClient.ts
+++ b/prismaEnzymesClient.ts
@@ -1,22 +1,18 @@
-﻿import { PrismaClient } from './prisma/generated/client_enzymes';
+﻿// prismaEnzymesClient.ts
+import { PrismaClient } from './prisma/generated/client_enzymes';
 
-const prismaEnzymes = new PrismaClient();
+const prismaEnzymesClientSingleton = () => new PrismaClient();
+
+type PrismaEnzymesClientSingleton = ReturnType<typeof prismaEnzymesClientSingleton>;
+
+const globalForPrismaEnzymes = globalThis as unknown as {
+  prismaEnzymes: PrismaEnzymesClientSingleton | undefined;
+};
+
+const prismaEnzymes = globalForPrismaEnzymes.prismaEnzymes ?? prismaEnzymesClientSingleton();
 
 export default prismaEnzymes;
 
-// import { PrismaClient } from './prisma/generated/client_enzymes'
-
-// declare global {
-//     var prismaEnzymes: any;
-//   }
-
-// if (process.env.NODE_ENV === 'production') {
-//   prismaEnzymes = new PrismaClient();
-// } else {
-//   if (!global.prismaEnzymes) {
-//     global.prismaEnzymes = new PrismaClient();
-//   }
-//   prismaEnzymes = global.prismaEnzymes;
-// }
-
-// export default prismaEnzymes;
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrismaEnzymes.prismaEnzymes = prismaEnzymes;
+}

--- a/prismaProteinsClient.ts
+++ b/prismaProteinsClient.ts
@@ -1,23 +1,18 @@
-﻿import { PrismaClient } from './prisma/generated/client_proteins';
+﻿// prismaProteinsClient.ts
+import { PrismaClient } from './prisma/generated/client_proteins';
 
-const prismaProteins = new PrismaClient();
+const prismaProteinsClientSingleton = () => new PrismaClient();
+
+type PrismaProteinsClientSingleton = ReturnType<typeof prismaProteinsClientSingleton>;
+
+const globalForPrismaProteins = globalThis as unknown as {
+  prismaProteins: PrismaProteinsClientSingleton | undefined;
+};
+
+const prismaProteins = globalForPrismaProteins.prismaProteins ?? prismaProteinsClientSingleton();
 
 export default prismaProteins;
 
-
-// import { PrismaClient } from './prisma/generated/client_proteins'
-
-// declare global {
-//     var prismaProteins: any;
-//   }
-
-// if (process.env.NODE_ENV === 'production') {
-//   prismaProteins = new PrismaClient();
-// } else {
-//   if (!global.prismaProteins) {
-//     global.prismaProteins = new PrismaClient();
-//   }
-//   prismaProteins = global.prismaProteins;
-// }
-
-// export default prismaProteins;
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrismaProteins.prismaProteins = prismaProteins;
+}

--- a/prismaUsersClient.ts
+++ b/prismaUsersClient.ts
@@ -1,22 +1,18 @@
-﻿import { PrismaClient } from './prisma/generated/client_users';
+﻿// prismaUsersClient.ts
+import { PrismaClient } from './prisma/generated/client_users';
 
-const prismaUsers = new PrismaClient();
+const prismaUsersClientSingleton = () => new PrismaClient();
+
+type PrismaUsersClientSingleton = ReturnType<typeof prismaUsersClientSingleton>;
+
+const globalForPrismaUsers = globalThis as unknown as {
+  prismaUsers: PrismaUsersClientSingleton | undefined;
+};
+
+const prismaUsers = globalForPrismaUsers.prismaUsers ?? prismaUsersClientSingleton();
 
 export default prismaUsers;
 
-// import { PrismaClient } from './prisma/generated/client_users'
-
-// declare global {
-//     var prismaUsers: any;
-//   }
-
-// if (process.env.NODE_ENV === 'production') {
-//   prismaUsers = new PrismaClient();
-// } else {
-//   if (!global.prismaUsers) {
-//     global.prismaUsers = new PrismaClient();
-//   }
-//   prismaUsers = global.prismaUsers;
-// }
-
-// export default prismaUsers;
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrismaUsers.prismaUsers = prismaUsers;
+}


### PR DESCRIPTION
- changed the clients file for prisma 
- set connection limit to 5 for each db connection 


i think the easiest fix would be switching from db.t3.micro to db.t3.medium on AWS, which would incur more monthly costs but would increase max connections to prevent timeouts. 